### PR TITLE
Removes branch flag and functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v3.2.0 (2021-04-09)
+## NEXT RELEASE
 
 * Removed `branch` flag and functionality as it was causing issues and inconsistencies when cloning/pulling and branches didn't match up. This became especially prevelant when repos started changing from `master` to `main`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.2.0 (2021-04-09)
+
+* Removed `branch` flag and functionality as it was causing issues and inconsistencies when cloning/pulling and branches didn't match up. This became especially prevelant when repos started changing from `master` to `main`
+
 ## v3.1.0 (2020-12-16)
 
 * Changed all classmethods to staticmethods

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A powerful script to concurrently clone your entire GitHub instance or save it a
 
 </div>
 
-GitHub Archive will clone any repo and gist that doesn't exist locally and pull those that do from your desired branch of each repo and latest revision of each gist that you have access to - including organizations (if configured).
+GitHub Archive will clone any repo and gist that doesn't exist locally and pull those that do from the main branch of each repo and latest revision of each gist that you have access to - including organizations (if configured).
 
 ## What Can it Do?
 
@@ -31,7 +31,6 @@ The power of GitHub Archive comes in its configuration. Maybe you only want to c
 * Organization repos cloning/pulling
 * Gists cloning/pulling
 * List of organizations to include
-* Which branch to clone/pull from
 * A host of environment variables to tweak GitHub Archive even further to meet your needs
 
 ## Install
@@ -68,7 +67,7 @@ Basic Usage:
 
 Advanced Usage:
     GITHUB_TOKEN=123... GITHUB_ARCHIVE_ORGS="org1, org2" GITHUB_ARCHIVE_LOCATION="~/custom_location" \
-    github-archive -uc -up -gc -gp -oc -op -b develop
+    github-archive -uc -up -gc -gp -oc -op
 
 Options:
     -h, --help            show this help message and exit
@@ -78,8 +77,6 @@ Options:
     -gp, --gists_pull     Pull personal gists.
     -oc, --orgs_clone     Clone organization repos.
     -op, --orgs_pull      Pull organization repos.
-    -b BRANCH, --branch BRANCH
-                            Which branch to pull from. If no branch is specified, the default repo branch will be used.
 
 Environment Variables:
     GITHUB_TOKEN                    expects a string of your GitHub Token

--- a/github_archive/cli.py
+++ b/github_archive/cli.py
@@ -1,4 +1,5 @@
 import argparse
+
 from github_archive import GithubArchive
 
 
@@ -7,8 +8,9 @@ class CLI():
         """Setup the CLI arguments
         """
         parser = argparse.ArgumentParser(
-            description=('A powerful script to concurrently clone your entire'
-                         ' GitHub instance or save it as an archive.')
+            description=(
+                'A powerful script to concurrently clone your entire GitHub instance or save it as an archive.'
+            )
         )
         parser.add_argument(
             '-uc',
@@ -58,13 +60,6 @@ class CLI():
             default=False,
             help='Pull organization repos.',
         )
-        parser.add_argument(
-            '-b',
-            '--branch',
-            required=False,
-            default=None,
-            help='Which branch to pull from. If no branch is specified, the default repo branch will be used.',
-        )
         parser.parse_args(namespace=self)
 
     def _run(self):
@@ -75,7 +70,6 @@ class CLI():
             gists_pull=self.gists_pull,
             orgs_clone=self.orgs_clone,
             orgs_pull=self.orgs_pull,
-            branch=self.branch,
         )
 
 


### PR DESCRIPTION
* Removed `branch` flag and functionality as it was causing issues and inconsistencies when cloning/pulling and branches didn't match up. This became especially prevelant when repos started changing from `master` to `main`