### PR TITLE
feat!: adds user list feature for archiving user repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## NEXT RELEASE
 
+### Breaking Changes
+
+* The `--user_clone` and `--user_pull` flags are now titled `--personal_clone` and `--personal_pull` as the new `--user_clone` and `--user_pull` flags are used for a list of specified users
+
+### Features
+
+* Adds the ability to specify a list of users via `GITHUB_ARCHIVE_USERS` to clone and pull repos for via the `--users_clone` and `--users_pull` flags (closes #20)
+
+### Fixes
+
 * Removed verbose logging of skipped actions (relegated them to the debugging logger). Added additional debug logging and user-readable logging related to API calls 
 * Adds proper validation of the `GITHUB_ARCHIVE_ORGS` variable on startup
 * Various code refactor, bug fixes, and optimizations

--- a/README_v4.md
+++ b/README_v4.md
@@ -1,0 +1,114 @@
+<div align="center">
+
+# GitHub Archive
+
+A powerful script to concurrently clone your entire GitHub instance or save it as an archive.
+
+[![Build Status](https://github.com/Justintime50/github-archive/workflows/build/badge.svg)](https://github.com/Justintime50/github-archive/actions)
+[![Coverage Status](https://coveralls.io/repos/github/Justintime50/github-archive/badge.svg?branch=main)](https://coveralls.io/github/Justintime50/github-archive?branch=main)
+[![PyPi](https://img.shields.io/pypi/v/github-archive)](https://pypi.org/project/github-archive)
+[![Licence](https://img.shields.io/github/license/justintime50/GitHub-archive)](LICENSE)
+
+<img src="assets/showcase.png" alt="Showcase">
+
+</div>
+
+GitHub Archive will clone any repo and gist that doesn't exist locally and pull those that do from the main branch of each repo and latest revision of each gist that you have access to - including organizations (if configured).
+
+## What Can it Do?
+
+* Clone/pull personal repos (public and private)
+* Clone/pull organization repos (public and private)
+* Clone/pull personal gists (public and private)
+* Iterate over infinite number of repos and gists concurrently
+* Great use case: Run on a schedule to automate pulling changes or keep a local backup of all your repos
+
+### Configurable Settings
+
+The power of GitHub Archive comes in its configuration. Maybe you only want to clone/pull your personal public repos or maybe you want to go all out and include private repos from you and all organizations you belong to including your gists. Iterate over all your repos concurrently and sit back while GitHub Archive does the work.
+
+* Personal repos cloning/pulling
+* Organization repos cloning/pulling
+* Gists cloning/pulling
+* List of organizations to include
+* A host of environment variables to tweak GitHub Archive even further to meet your needs
+
+## Install
+
+```bash
+# Install tool
+pip3 install github-archive
+
+# Install locally
+make install
+
+# Get Makefile help
+make help
+``` 
+
+### Automating SSH Passphrase Prompt (Recommended)
+
+To allow the script to run continuosly without requiring your SSH passphrase, you'll need to add your passphrase to the SSH agent. **NOTE:** Your SSH passphrase will be unloaded upon logout.
+
+```bash
+# This assumes you've saved your SSH keys to the default location
+ssh-add
+```
+
+## Usage
+
+**SSH Key:** You must have an SSH key generated on your local machine and added to your GitHub account as this tool uses the `ssh_url` to clone/pull. 
+
+**Merge Conflicts:** Be aware that using GitHub Archive could lead to merge conflicts if you do not commit or stash your changes if using these repos as active development repos instead of simply an archive or one-time clone.
+
+**Access**: GitHub Archive can only clone or pull repos that the authenticated user has access to. That means that private repos from another user or orgs that you don't have access to will not be able to be cloned or pulled.
+
+```
+Basic Usage:
+    GITHUB_TOKEN=123... github-archive --personal-clone --personal-pull
+
+Advanced Usage:
+    GITHUB_TOKEN=123... GITHUB_ARCHIVE_ORGS="org1, org2" GITHUB_ARCHIVE_LOCATION="~/custom_location" \
+    github-archive -pc -pp -uc -up -gc -gp -oc -op
+
+Options:
+    -h, --help            show this help message and exit
+    -pc, --personal_clone Clone personal repos.
+    -pp, --personal_pull  Pull personal repos
+    -uc, --user_clone     Clone user repos.
+    -up, --user_pull      Pull user repos.
+    -gc, --gists_clone    Clone personal gists.
+    -gp, --gists_pull     Pull personal gists.
+    -oc, --orgs_clone     Clone organization repos.
+    -op, --orgs_pull      Pull organization repos.
+
+Environment Variables:
+    GITHUB_TOKEN                    expects a string of your GitHub Token
+    GITHUB_ARCHIVE_USERS            expects a string of comma separated GitHub usernames. eg: "user1, user2"
+    GITHUB_ARCHIVE_ORGS             expects a string of comma separated GitHub organizations. eg: "org1, org2"
+    GITHUB_ARCHIVE_LOCATION         expects a string of an explicit location on your machine (eg: "~/custom_location"). Default: ~/github-archive
+    GITHUB_ARCHIVE_BUFFER           expects a float for the buffer inbetween requests. Default: 0.1
+    GITHUB_ARCHIVE_TIMEOUT          expects an int for the number of seconds before a git operation times out. Default: 180
+    GITHUB_ARCHIVE_LOG_MAX_BYTES    expects an int of the max bytes that a log will grow to. Once the log exceeds this number, it will rollover to another log. Default: 200000
+    GITHUB_ARCHIVE_LOG_BACKUP_COUNT expects an int of the number of logs to rollover once a single log exceeds the max bytes size. Default: 5
+```
+
+## Development
+
+```bash
+# Lint the project
+make lint
+
+# Run tests
+make test
+
+# Run test coverage
+make coverage
+
+# Run the tool locally
+venv/bin/python github_archive/cli.py --help
+```
+
+## Legacy Script
+
+This tool was initially built in Bash and later re-written in Python. If you'd like to use or view the legacy script, check out the separate [Legacy README](legacy/README.md).

--- a/github_archive/cli.py
+++ b/github_archive/cli.py
@@ -12,20 +12,36 @@ class CLI:
             )
         )
         parser.add_argument(
-            '-uc',
-            '--user_clone',
+            '-pc',
+            '--personal_clone',
             action='store_true',
             required=False,
             default=False,
             help='Clone personal repos.',
         )
         parser.add_argument(
-            '-up',
-            '--user_pull',
+            '-pp',
+            '--personal_pull',
             action='store_true',
             required=False,
             default=False,
             help='Pull personal repos',
+        )
+        parser.add_argument(
+            '-uc',
+            '--users_clone',
+            action='store_true',
+            required=False,
+            default=False,
+            help='Clone user repos.',
+        )
+        parser.add_argument(
+            '-up',
+            '--users_pull',
+            action='store_true',
+            required=False,
+            default=False,
+            help='Pull user repos.',
         )
         parser.add_argument(
             '-gc',
@@ -33,7 +49,7 @@ class CLI:
             action='store_true',
             required=False,
             default=False,
-            help='Clone personal gists',
+            help='Clone personal gists.',
         )
         parser.add_argument(
             '-gp',
@@ -63,8 +79,10 @@ class CLI:
 
     def _run(self):
         GithubArchive.run(
-            user_clone=self.user_clone,
-            user_pull=self.user_pull,
+            personal_clone=self.personal_clone,
+            personal_pull=self.personal_pull,
+            users_clone=self.users_clone,
+            users_pull=self.users_pull,
             gists_clone=self.gists_clone,
             gists_pull=self.gists_pull,
             orgs_clone=self.orgs_clone,


### PR DESCRIPTION
### Breaking Changes

* The `--user_clone` and `--user_pull` flags are now titled `--personal_clone` and `--personal_pull` as the new `--user_clone` and `--user_pull` flags are used for a list of specified users

### Features

* Adds the ability to specify a list of users via `GITHUB_ARCHIVE_USERS` to clone and pull repos for via the `--users_clone` and `--users_pull` flags (closes #20)