### PR TITLE
feat: adds a new threads flag and bumps timeout up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@
 ### Features
 
 * Adds the ability to specify a list of users via `GITHUB_ARCHIVE_USERS` to clone and pull repos for via the `--users_clone` and `--users_pull` flags (closes #20)
+* Added the `--threads` flag which can specify the number of concurrent threads to run at once (closes #22)
 
 ### Fixes
 
 * Removed verbose logging of skipped actions (relegated them to the debugging logger). Added additional debug logging and user-readable logging related to API calls 
 * Adds proper validation of the `GITHUB_ARCHIVE_ORGS` variable on startup
 * Various code refactor, bug fixes, and optimizations
+* Bumped the default git operation timeout from 180 seconds to 300 seconds for larger repos (closes #22)
 
 ## v3.1.1 (2021-07-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking Changes
 
 * The `--user_clone` and `--user_pull` flags are now titled `--personal_clone` and `--personal_pull` as the new `--user_clone` and `--user_pull` flags are used for a list of specified users
+* Removes the `GITHUB_ARCHIVE_BUFFER` environment variable in favor of the new `--threads` flag
 
 ### Features
 

--- a/README_v4.md
+++ b/README_v4.md
@@ -81,14 +81,14 @@ Options:
     -gp, --gists_pull     Pull personal gists.
     -oc, --orgs_clone     Clone organization repos.
     -op, --orgs_pull      Pull organization repos.
+    -t, --threads         The number of concurrent threads to run. (default is 10)
 
 Environment Variables:
     GITHUB_TOKEN                    expects a string of your GitHub Token
     GITHUB_ARCHIVE_USERS            expects a string of comma separated GitHub usernames. eg: "user1, user2"
     GITHUB_ARCHIVE_ORGS             expects a string of comma separated GitHub organizations. eg: "org1, org2"
     GITHUB_ARCHIVE_LOCATION         expects a string of an explicit location on your machine (eg: "~/custom_location"). Default: ~/github-archive
-    GITHUB_ARCHIVE_BUFFER           expects a float for the buffer inbetween requests. Default: 0.1
-    GITHUB_ARCHIVE_TIMEOUT          expects an int for the number of seconds before a git operation times out. Default: 180
+    GITHUB_ARCHIVE_TIMEOUT          expects an int for the number of seconds before a git operation times out. Default: 300
     GITHUB_ARCHIVE_LOG_MAX_BYTES    expects an int of the max bytes that a log will grow to. Once the log exceeds this number, it will rollover to another log. Default: 200000
     GITHUB_ARCHIVE_LOG_BACKUP_COUNT expects an int of the number of logs to rollover once a single log exceeds the max bytes size. Default: 5
 ```

--- a/github_archive/archive.py
+++ b/github_archive/archive.py
@@ -278,6 +278,7 @@ class GithubArchive:
             git_command = commands[operation]
 
             try:
+                thread_limiter.acquire()
                 subprocess.run(
                     git_command,
                     stdin=subprocess.DEVNULL,

--- a/github_archive/archive.py
+++ b/github_archive/archive.py
@@ -1,15 +1,13 @@
 import logging
 import os
 import subprocess
-import time
 from datetime import datetime
-from threading import Thread
+from threading import BoundedSemaphore, Thread
 
 from github import Github
 
 from github_archive.logger import Logger
 
-# TODO: Add user/password authentication (will need to pull from non-ssh url)
 GITHUB_TOKEN = os.getenv('GITHUB_TOKEN')
 GITHUB_LOGIN = Github(GITHUB_TOKEN)
 AUTHENTICATED_GITHUB_USER = GITHUB_LOGIN.get_user()
@@ -18,11 +16,9 @@ ORGS = ORG_LIST.split(',')
 USER_LIST = os.getenv('GITHUB_ARCHIVE_USERS', '')
 USERS = USER_LIST.split(',')
 
-GIT_TIMEOUT = int(os.getenv('GITHUB_ARCHIVE_TIMEOUT', 180))
+GIT_TIMEOUT = int(os.getenv('GITHUB_ARCHIVE_TIMEOUT', 300))
 GITHUB_ARCHIVE_LOCATION = os.path.expanduser(os.getenv('GITHUB_ARCHIVE_LOCATION', '~/github-archive'))
-SUBPROCESS_BUFFER = float(
-    os.getenv('GITHUB_ARCHIVE_BUFFER', 0.1)
-)  # TODO: This can most likely be removed once we limit the number of open threads at once
+DEFAULT_NUM_THREADS = 10
 
 LOGGER = logging.getLogger(__name__)
 CLONE_OPERATION = 'clone'
@@ -43,6 +39,7 @@ class GithubArchive:
         gists_pull=False,
         orgs_clone=False,
         orgs_pull=False,
+        num_of_threads=DEFAULT_NUM_THREADS,
     ):
         """Run the tool based on the arguments passed."""
         GithubArchive.initialize_project(users_clone, users_pull, orgs_clone, orgs_pull)
@@ -51,6 +48,9 @@ class GithubArchive:
         start_time = datetime.now()
 
         # Make API calls
+        # TODO: If we decide to remove the `personal` flag here, we need a new way to get private repos
+        # for the authenticated user. We could do this by making a separate API call to the get_user endpoint
+        # of the users passing the API key based on the name in the `users` list and the authed user.
         if personal_clone or personal_pull:
             LOGGER.info('# Making API call to GitHub for personal repos...\n')
             personal_repos = GithubArchive.get_personal_repos()
@@ -65,33 +65,35 @@ class GithubArchive:
             gists = GithubArchive.get_gists()
 
         # Git operations
+        # TODO: Rework a class that can share all these values so we don't need to pass
+        # along all these variables across the app.
         if personal_clone is True:
             LOGGER.info('# Cloning missing personal repos...\n')
-            GithubArchive.iterate_repos_to_archive(personal_repos, PERSONAL_CONTEXT, CLONE_OPERATION)
+            GithubArchive.iterate_repos_to_archive(num_of_threads, personal_repos, PERSONAL_CONTEXT, CLONE_OPERATION)
         if personal_pull is True:
             LOGGER.info('# Pulling personal repos...\n')
-            GithubArchive.iterate_repos_to_archive(personal_repos, PERSONAL_CONTEXT, PULL_OPERATION)
+            GithubArchive.iterate_repos_to_archive(num_of_threads, personal_repos, PERSONAL_CONTEXT, PULL_OPERATION)
 
         if users_clone is True:
             LOGGER.info('# Cloning missing user repos...\n')
-            GithubArchive.iterate_repos_to_archive(user_repos, USER_CONTEXT, CLONE_OPERATION)
+            GithubArchive.iterate_repos_to_archive(num_of_threads, user_repos, USER_CONTEXT, CLONE_OPERATION)
         if users_pull is True:
             LOGGER.info('# Pulling user repos...\n')
-            GithubArchive.iterate_repos_to_archive(user_repos, USER_CONTEXT, PULL_OPERATION)
+            GithubArchive.iterate_repos_to_archive(num_of_threads, user_repos, USER_CONTEXT, PULL_OPERATION)
 
         if orgs_clone is True:
             LOGGER.info('# Cloning missing org repos...\n')
-            GithubArchive.iterate_repos_to_archive(org_repos, ORG_CONTEXT, CLONE_OPERATION)
+            GithubArchive.iterate_repos_to_archive(num_of_threads, org_repos, ORG_CONTEXT, CLONE_OPERATION)
         if orgs_pull is True:
             LOGGER.info('# Pulling org repos...\n')
-            GithubArchive.iterate_repos_to_archive(org_repos, ORG_CONTEXT, PULL_OPERATION)
+            GithubArchive.iterate_repos_to_archive(num_of_threads, org_repos, ORG_CONTEXT, PULL_OPERATION)
 
         if gists_clone is True:
             LOGGER.info('# Cloning missing gists...\n')
-            GithubArchive.iterate_gists_to_archive(gists, CLONE_OPERATION)
+            GithubArchive.iterate_gists_to_archive(num_of_threads, gists, CLONE_OPERATION)
         if gists_pull is True:
             LOGGER.info('# Pulling gists...\n')
-            GithubArchive.iterate_gists_to_archive(gists, PULL_OPERATION)
+            GithubArchive.iterate_gists_to_archive(num_of_threads, gists, PULL_OPERATION)
 
         execution_time = f'Execution time: {datetime.now() - start_time}.'
         finish_message = f'GitHub Archive complete! {execution_time}\n'
@@ -170,7 +172,7 @@ class GithubArchive:
         return gists
 
     @staticmethod
-    def iterate_repos_to_archive(repos, context, operation):
+    def iterate_repos_to_archive(num_of_threads, repos, context, operation):
         """Iterate over each repository and start a thread if it can be archived."""
         thread_list = []
         for repo in repos:
@@ -185,11 +187,12 @@ class GithubArchive:
             if repo.owner.name != AUTHENTICATED_GITHUB_USER.name and context == PERSONAL_CONTEXT:
                 continue
             else:
-                time.sleep(SUBPROCESS_BUFFER)
+                thread_limiter = BoundedSemaphore(num_of_threads)
                 repo_path = os.path.join(GITHUB_ARCHIVE_LOCATION, 'repos', repo.owner.login, repo.name)
                 repo_thread = Thread(
                     target=GithubArchive.archive_repo,
                     args=(
+                        thread_limiter,
                         repo,
                         repo_path,
                         operation,
@@ -201,15 +204,16 @@ class GithubArchive:
             thread.join()
 
     @staticmethod
-    def iterate_gists_to_archive(gists, operation):
+    def iterate_gists_to_archive(num_of_threads, gists, operation):
         """Iterate over each gist and start a thread if it can be archived."""
+        thread_limiter = BoundedSemaphore(num_of_threads)
         thread_list = []
         for gist in gists:
-            time.sleep(SUBPROCESS_BUFFER)
             gist_path = os.path.join(GITHUB_ARCHIVE_LOCATION, 'gists', gist.id)
             gist_thread = Thread(
                 target=GithubArchive.archive_gist,
                 args=(
+                    thread_limiter,
                     gist,
                     gist_path,
                     operation,
@@ -221,12 +225,14 @@ class GithubArchive:
             thread.join()
 
     @staticmethod
-    def archive_repo(repo, repo_path, operation):
+    def archive_repo(thread_limiter, repo, repo_path, operation):
         """Clone and pull repos based on the operation passed"""
         if os.path.exists(repo_path) and operation == CLONE_OPERATION:
             # TODO: There is a bug here if a repo times out or has another error but the folder got created
             # where the repo won't finish getting cloned and therefore can't reliably get pulled in the future.
             # Look into a better way to assert this was successful before skipping.
+            # TODO: Move the debug line into the exception block and delete the failed folder so that on a future
+            # run, the app will attempt to re-clone the project
             LOGGER.debug(f'Repo: {repo.name} already cloned, skipping clone operation.')
         else:
             commands = {
@@ -236,6 +242,7 @@ class GithubArchive:
             git_command = commands[operation]
 
             try:
+                thread_limiter.acquire()
                 subprocess.run(
                     git_command,
                     stdin=subprocess.DEVNULL,
@@ -250,14 +257,18 @@ class GithubArchive:
                 LOGGER.error(f'Git operation timed out archiving {repo.name}.')
             except subprocess.CalledProcessError as error:
                 LOGGER.error(f'Failed to {operation} {repo.name}\n{error}')
+            finally:
+                thread_limiter.release()
 
     @staticmethod
-    def archive_gist(gist, gist_path, operation):
+    def archive_gist(thread_limiter, gist, gist_path, operation):
         """Clone and pull gists based on the operation passed"""
         if os.path.exists(gist_path) and operation == CLONE_OPERATION:
             # TODO: There is a bug here if a repo times out or has another error but the folder got created
             # where the repo won't finish getting cloned and therefore can't reliably get pulled in the future.
             # Look into a better way to assert this was successful before skipping.
+            # TODO: Move the debug line into the exception block and delete the failed folder so that on a future
+            # run, the app will attempt to re-clone the project
             LOGGER.debug(f'Gist: {gist.id} already cloned, skipping clone operation.')
         else:
             commands = {
@@ -281,3 +292,5 @@ class GithubArchive:
                 LOGGER.error(f'Git operation timed out archiving {gist.id}.')
             except subprocess.CalledProcessError as error:
                 LOGGER.error(f'Failed to {operation} {gist.id}\n{error}')
+            finally:
+                thread_limiter.release()

--- a/github_archive/cli.py
+++ b/github_archive/cli.py
@@ -1,6 +1,7 @@
 import argparse
 
 from github_archive import GithubArchive
+from github_archive.archive import DEFAULT_NUM_THREADS
 
 
 class CLI:
@@ -75,6 +76,14 @@ class CLI:
             default=False,
             help='Pull organization repos.',
         )
+        parser.add_argument(
+            '-t',
+            '--threads',
+            required=False,
+            type=int,
+            default=DEFAULT_NUM_THREADS,
+            help='The number of concurrent threads to run.',
+        )
         parser.parse_args(namespace=self)
 
     def _run(self):
@@ -87,6 +96,7 @@ class CLI:
             gists_pull=self.gists_pull,
             orgs_clone=self.orgs_clone,
             orgs_pull=self.orgs_pull,
+            num_of_threads=self.threads,
         )
 
 

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,13 +1,13 @@
-import pytest
 import mock
+import pytest
 
 
 @pytest.fixture
 def mock_object():
-    """This can be used for repos and/or gists
-    """
+    """This can be used for repos and/or gists"""
     mock_object = mock.MagicMock()
     mock_object.id = '123'
     mock_object.name = 'Mock Name'
     mock_object.owner.name = 'Mock Name'
+
     return mock_object


### PR DESCRIPTION
* Added the `--threads` flag which can specify the number of concurrent threads to run at once (closes #22)
* Removes the `GITHUB_ARCHIVE_BUFFER` environment variable in favor of the new `--threads` flag
* Bumped the default git operation timeout from 180 seconds to 300 seconds for larger repos (closes #22)
