### PR TITLE
Add Option to use Anon HTTPS URIs instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Options:
                             Provide your GitHub token to authenticate with the GitHub API and gain access to private repos and gists.
     -l LOCATION, --location LOCATION
                             The location where you want your GitHub Archive to be stored.
+    -ht, --https           Use HTTPS URLs instead of SSH.
 ```
 
 ### Automating SSH Passphrase Prompt (Recommended)

--- a/github_archive/archive.py
+++ b/github_archive/archive.py
@@ -37,6 +37,7 @@ class GithubArchive:
         threads=DEFAULT_NUM_THREADS,
         token=None,
         location=DEFAULT_LOCATION,
+        use_https=False
     ):
         # Parameter variables
         self.view = view
@@ -51,6 +52,7 @@ class GithubArchive:
         self.threads = threads
         self.token = token
         self.location = location
+        self.use_https = use_https
         # Internal variables
         self.github_instance = Github(self.token) if self.token else Github()
         self.authenticated_user = self.github_instance.get_user() if self.token else None
@@ -270,9 +272,13 @@ class GithubArchive:
             pass
         else:
             commands = {
-                CLONE_OPERATION: f'git clone {repo.ssh_url} {repo_path}',
                 PULL_OPERATION: f'cd {repo_path} && git pull --rebase',
             }
+
+            if self.use_https:
+                commands.update({CLONE_OPERATION: f'git clone {repo.html_url} {repo_path}'})
+            else:
+                commands.update({CLONE_OPERATION: f'git clone {repo.ssh_url} {repo_path}'})
             git_command = commands[operation]
 
             try:

--- a/github_archive/archive.py
+++ b/github_archive/archive.py
@@ -37,7 +37,7 @@ class GithubArchive:
         threads=DEFAULT_NUM_THREADS,
         token=None,
         location=DEFAULT_LOCATION,
-        use_https=False
+        use_https=False,
     ):
         # Parameter variables
         self.view = view

--- a/github_archive/cli.py
+++ b/github_archive/cli.py
@@ -110,6 +110,14 @@ class GithubArchiveCli:
             default=DEFAULT_LOCATION,
             help='The location where you want your GitHub Archive to be stored.',
         )
+        parser.add_argument(
+            '-ht',
+            '--https',
+            action='store_true',
+            required=False,
+            default=False,
+            help='Use HTTPS URLs instead of SSH.'
+        )
         parser.parse_args(namespace=self)
 
     def run(self):
@@ -126,6 +134,7 @@ class GithubArchiveCli:
             threads=self.threads,
             token=self.token,
             location=self.location,
+            use_https=self.https
         )
         github_archive.run()
 

--- a/github_archive/cli.py
+++ b/github_archive/cli.py
@@ -116,7 +116,7 @@ class GithubArchiveCli:
             action='store_true',
             required=False,
             default=False,
-            help='Use HTTPS URLs instead of SSH.'
+            help='Use HTTPS URLs instead of SSH.',
         )
         parser.parse_args(namespace=self)
 
@@ -134,7 +134,7 @@ class GithubArchiveCli:
             threads=self.threads,
             token=self.token,
             location=self.location,
-            use_https=self.https
+            use_https=self.https,
         )
         github_archive.run()
 


### PR DESCRIPTION
Without this option, the only URL used to clone a repo was the SSH URL.
This adds a simple flag to switch clone operations to using the HTTPS
URL. The default behavior of using SSH is preserved so as to not break
scripts, etc.

Tested and seems to work just fine. 

I tried to follow the conventions already established -- I suppose one improvement would be to move the new arg higher in the parser list....