### PR TITLE
chore: prepare project for v4.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v4.1.0 (2021-09-19)
+
+* Adds a new `--https` flag which will authenticate via HTTPS instead of the default `SSH`
+* Fixes a bug where using the `--stars` flag would not properly run due to a missing parameter. This parameter wasn't actually being used anymore and has been removed. Tests were beefed up for this function to protect against this happening again
+
 ## v4.0.0 (2021-08-24)
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -40,10 +40,8 @@ Usage:
 
 Options:
     -h, --help            show this help message and exit
-    -v, --view            Pass this flag to view git assets (dry run).
-    -c, --clone           Pass this flag to clone git assets.
-    -p, --pull            Pass this flag to pull git assets.
-    -f, --forks           Pass this flag to include forked git assets.
+    -t TOKEN, --token TOKEN
+                            Provide your GitHub token to authenticate with the GitHub API and gain access to private repos and gists.
     -u USERS, --users USERS
                             Pass a comma separated list of users to get repos for.
     -o ORGS, --orgs ORGS  Pass a comma separated list of orgs to get repos for.
@@ -51,15 +49,17 @@ Options:
                             Pass a comma separated list of users to get gists for.
     -s STARS, --stars STARS
                             Pass a comma separated list of users to get starred repos for.
+    -v, --view            Pass this flag to view git assets (dry run).
+    -c, --clone           Pass this flag to clone git assets.
+    -p, --pull            Pass this flag to pull git assets.
+    -f, --forks           Pass this flag to include forked git assets.
+    -l LOCATION, --location LOCATION
+                            The location where you want your GitHub Archive to be stored.
+    -ht, --https          Use HTTPS URLs instead of SSH.
     -to TIMEOUT, --timeout TIMEOUT
                             The number of seconds before a git operation times out.
     -th THREADS, --threads THREADS
                             The number of concurrent threads to run.
-    -t TOKEN, --token TOKEN
-                            Provide your GitHub token to authenticate with the GitHub API and gain access to private repos and gists.
-    -l LOCATION, --location LOCATION
-                            The location where you want your GitHub Archive to be stored.
-    -ht, --https           Use HTTPS URLs instead of SSH.
 ```
 
 ### Automating SSH Passphrase Prompt (Recommended)
@@ -73,11 +73,11 @@ ssh-add
 
 ### Notes
 
-**SSH Key:** You must have an SSH key generated on your local machine and added to your GitHub account as this tool uses the `ssh_url` to clone/pull. 
+**SSH Key:** By default, you must have an SSH key generated on your local machine and added to your GitHub account as this tool uses the `ssh_url` to clone/pull. If you'd like to instead use the `git_url` to clone/pull, you can pass the `--https` flag which will authenticate with your username and password.
 
 **Merge Conflicts:** Be aware that using GitHub Archive could lead to merge conflicts if you do not commit or stash your changes if using these repos as active development repos instead of simply an archive or one-time clone.
 
-**Access**: GitHub Archive can only clone or pull repos that the authenticated user has access to. This means that private repos from another user or org that you don't have access to will not be able to be cloned or pulled.
+**Access**: GitHub Archive can only clone or pull git assets that the authenticated user has access to. This means that private repos from another user or org that you don't have access to will not be able to be cloned or pulled.
 
 ## Development
 

--- a/github_archive/archive.py
+++ b/github_archive/archive.py
@@ -25,34 +25,35 @@ USER_CONTEXT = 'user'
 class GithubArchive:
     def __init__(
         self,
-        view=False,
-        clone=False,
-        pull=False,
-        forks=False,
+        token=None,
         users=None,
         orgs=None,
         gists=None,
         stars=None,
-        timeout=DEFAULT_TIMEOUT,
-        threads=DEFAULT_NUM_THREADS,
-        token=None,
+        view=False,
+        clone=False,
+        pull=False,
+        forks=False,
         location=DEFAULT_LOCATION,
         use_https=False,
+        timeout=DEFAULT_TIMEOUT,
+        threads=DEFAULT_NUM_THREADS,
     ):
         # Parameter variables
-        self.view = view
-        self.clone = clone
-        self.pull = pull
-        self.forks = forks
+        self.token = token
         self.users = users.lower().split(',') if users else ''
         self.orgs = orgs.lower().split(',') if orgs else ''
         self.gists = gists.lower().split(',') if gists else ''
         self.stars = stars.lower().split(',') if stars else ''
-        self.timeout = timeout
-        self.threads = threads
-        self.token = token
+        self.view = view
+        self.clone = clone
+        self.pull = pull
+        self.forks = forks
         self.location = location
         self.use_https = use_https
+        self.timeout = timeout
+        self.threads = threads
+
         # Internal variables
         self.github_instance = Github(self.token) if self.token else Github()
         self.authenticated_user = self.github_instance.get_user() if self.token else None

--- a/github_archive/cli.py
+++ b/github_archive/cli.py
@@ -12,36 +12,15 @@ class GithubArchiveCli:
             )
         )
         parser.add_argument(
-            '-v',
-            '--view',
-            action='store_true',
+            '-t',
+            '--token',
+            type=str,
             required=False,
-            default=False,
-            help='Pass this flag to view git assets (dry run).',
-        )
-        parser.add_argument(
-            '-c',
-            '--clone',
-            action='store_true',
-            required=False,
-            default=False,
-            help='Pass this flag to clone git assets.',
-        )
-        parser.add_argument(
-            '-p',
-            '--pull',
-            action='store_true',
-            required=False,
-            default=False,
-            help='Pass this flag to pull git assets.',
-        )
-        parser.add_argument(
-            '-f',
-            '--forks',
-            action='store_true',
-            required=False,
-            default=False,
-            help='Pass this flag to include forked git assets.',
+            default=None,
+            help=(
+                'Provide your GitHub token to authenticate with the GitHub API and gain access to private repos and'
+                ' gists.'
+            ),
         )
         parser.add_argument(
             '-u',
@@ -76,31 +55,36 @@ class GithubArchiveCli:
             help='Pass a comma separated list of users to get starred repos for.',
         )
         parser.add_argument(
-            '-to',
-            '--timeout',
-            type=int,
+            '-v',
+            '--view',
+            action='store_true',
             required=False,
-            default=DEFAULT_TIMEOUT,
-            help='The number of seconds before a git operation times out.',
+            default=False,
+            help='Pass this flag to view git assets (dry run).',
         )
         parser.add_argument(
-            '-th',
-            '--threads',
-            type=int,
+            '-c',
+            '--clone',
+            action='store_true',
             required=False,
-            default=DEFAULT_NUM_THREADS,
-            help='The number of concurrent threads to run.',
+            default=False,
+            help='Pass this flag to clone git assets.',
         )
         parser.add_argument(
-            '-t',
-            '--token',
-            type=str,
+            '-p',
+            '--pull',
+            action='store_true',
             required=False,
-            default=None,
-            help=(
-                'Provide your GitHub token to authenticate with the GitHub API and gain access to private repos and'
-                ' gists.'
-            ),
+            default=False,
+            help='Pass this flag to pull git assets.',
+        )
+        parser.add_argument(
+            '-f',
+            '--forks',
+            action='store_true',
+            required=False,
+            default=False,
+            help='Pass this flag to include forked git assets.',
         )
         parser.add_argument(
             '-l',
@@ -118,23 +102,39 @@ class GithubArchiveCli:
             default=False,
             help='Use HTTPS URLs instead of SSH.',
         )
+        parser.add_argument(
+            '-to',
+            '--timeout',
+            type=int,
+            required=False,
+            default=DEFAULT_TIMEOUT,
+            help='The number of seconds before a git operation times out.',
+        )
+        parser.add_argument(
+            '-th',
+            '--threads',
+            type=int,
+            required=False,
+            default=DEFAULT_NUM_THREADS,
+            help='The number of concurrent threads to run.',
+        )
         parser.parse_args(namespace=self)
 
     def run(self):
         github_archive = GithubArchive(
-            view=self.view,
-            clone=self.clone,
-            pull=self.pull,
-            forks=self.forks,
+            token=self.token,
             users=self.users,
             orgs=self.orgs,
             gists=self.gists,
             stars=self.stars,
-            timeout=self.timeout,
-            threads=self.threads,
-            token=self.token,
+            view=self.view,
+            clone=self.clone,
+            pull=self.pull,
+            forks=self.forks,
             location=self.location,
             use_https=self.https,
+            timeout=self.timeout,
+            threads=self.threads,
         )
         github_archive.run()
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ DEV_REQUIREMENTS = [
 
 setuptools.setup(
     name='github-archive',
-    version='4.0.0',
+    version='4.1.0',
     description=(
         'A powerful tool to concurrently clone or pull user and org repos and gists to create a GitHub archive.'
     ),


### PR DESCRIPTION
TODO:
* Wait until coveralls isn't down for maintenance and re-run the build. Once it passes, this can be merged and `v4.1.0` released.

CHANGES:
* Adds a new `--https` flag which will authenticate via HTTPS instead of the default `SSH`
* Fixes a bug where using the `--stars` flag would not properly run due to a missing parameter. This parameter wasn't actually being used anymore and has been removed. Tests were beefed up for this function to protect against this happening again