### PR TITLE
feat: support forking repos and gists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT RELEASE
 
+- Adds a new `--fork` CLI arg which adds support to fork the repos or gists specified via `users`, `orgs`, `stars`, or `gists`
+- Removed various shorthand CLI args to avoid confusion and improved help message output for CLI args (updated docs as well)
 - Namespaces for various functions changed for better project organization. As this project is intended to be used as a CLI tool and not a library, the impact should be minimal
 
 ## 4.5.1 (2022-09-15)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # GitHub Archive
 
-A powerful tool to concurrently clone or pull user and org repos and gists to create a GitHub archive.
+A powerful tool to concurrently clone, pull, or fork user and org repos and gists to create a GitHub archive.
 
 [![Build Status](https://github.com/Justintime50/github-archive/workflows/build/badge.svg)](https://github.com/Justintime50/github-archive/actions)
 [![Coverage Status](https://coveralls.io/repos/github/Justintime50/github-archive/badge.svg?branch=main)](https://coveralls.io/github/Justintime50/github-archive?branch=main)
@@ -13,7 +13,7 @@ A powerful tool to concurrently clone or pull user and org repos and gists to cr
 
 </div>
 
-GitHub Archive is a powerful tool to concurrently clone or pull repositories or gists from GitHub with incredible flexibility. It's the perfect tool for spinning up a new dev environment, keeping a local copy of your GitHub instance, or quickly pulling in projects from your favorite users and organizations.
+GitHub Archive is a powerful tool to concurrently clone, pull, or fork repositories or gists from GitHub with incredible flexibility. It's the perfect tool for spinning up a new dev environment, keeping a local copy of your GitHub instance, or quickly pulling in projects from your favorite users and organizations.
 
 The power of GitHub Archive comes in its configuration. Maybe you only want to clone or pull your personal public repos or maybe you want to go all out and include private repos from you and all organizations you belong to along with your gists. GitHub Archive can do it all.
 
@@ -47,21 +47,17 @@ Options:
     -v, --view            Pass this flag to view git assets (dry run).
     -c, --clone           Pass this flag to clone git assets.
     -p, --pull            Pass this flag to pull git assets.
-    -f, --forks           Pass this flag to include forked git assets.
-    -i INCLUDE, --include INCLUDE
-                            Pass a comma separated list of repos to filter what is included in the Archive.
-    -e EXCLUDE, --exclude EXCLUDE
-                            Pass a comma separated list of repos to filter what is excluded from the Archive.
-    -l LOCATION, --location LOCATION
-                            The location where you want your GitHub Archive to be stored. By default, this is /Users/USERNAME/github-archive
-    -ht, --https          Use HTTPS URLs instead of SSH.
-    -to TIMEOUT, --timeout TIMEOUT
-                            The number of seconds before a git operation times out.
-    -th THREADS, --threads THREADS
-                            The number of concurrent threads to run.
-    --base_url BASE_URL   The base URL of your GitHub instance (useful for enterprise users with custom hostnames).
-    --log_level {error,debug,warning,info,critical}
-                            The log level used for the tool.
+    -f, --fork            Pass this flag to fork git assets.
+    --include INCLUDE     Pass a comma separated list of repos to filter what is included in the Archive.
+    --exclude EXCLUDE     Pass a comma separated list of repos to filter what is excluded from the Archive.
+    --forks               Pass this flag to include forked git assets (when cloning or pulling).
+    --location LOCATION   The location where you want your GitHub Archive to be stored. Default: /Users/USERNAME/github-archive
+    --https               Use HTTPS URLs instead of SSH.
+    --timeout TIMEOUT     The number of seconds before a git operation times out. Default: 300
+    --threads THREADS     The number of concurrent threads to run. Default: 10
+    --base_url BASE_URL   The base URL of your GitHub instance (useful for enterprise users with custom hostnames). Default: https://api.github.com
+    --log_level {error,critical,warning,info,debug}
+                            The log level used for the tool. Default: info
 ```
 
 ### Automating SSH Passphrase Prompt (Recommended)

--- a/github_archive/archive.py
+++ b/github_archive/archive.py
@@ -31,6 +31,7 @@ from github_archive.constants import (
 )
 from github_archive.gists import (
     iterate_gists_to_archive,
+    iterate_gists_to_fork,
     view_gists,
 )
 from github_archive.logger import (
@@ -39,6 +40,7 @@ from github_archive.logger import (
 )
 from github_archive.repos import (
     iterate_repos_to_archive,
+    iterate_repos_to_fork,
     view_repos,
 )
 
@@ -114,6 +116,9 @@ class GithubArchive:
             if self.pull:
                 logger.info('# Pulling changes to personal repos...\n')
                 _ = iterate_repos_to_archive(self, personal_repos, PULL_OPERATION)
+            if self.fork:
+                # We can't fork a repo we already have, do nothing
+                pass
 
             # We remove the authenticated user from the list so that we don't double pull their
             # repos for the `users` logic.
@@ -135,6 +140,9 @@ class GithubArchive:
             if self.pull:
                 logger.info('# Pulling changes to user repos...\n')
                 _ = iterate_repos_to_archive(self, user_repos, PULL_OPERATION)
+            if self.fork:
+                logger.info('# Forking starred repos...\n')
+                iterate_repos_to_fork(user_repos)
 
         # Orgs
         if self.orgs:
@@ -152,6 +160,9 @@ class GithubArchive:
             if self.pull:
                 logger.info('# Pulling changes to org repos...\n')
                 _ = iterate_repos_to_archive(self, org_repos, PULL_OPERATION)
+            if self.fork:
+                logger.info('# Forking starred repos...\n')
+                iterate_repos_to_fork(org_repos)
 
         # Stars
         if self.stars:
@@ -169,6 +180,9 @@ class GithubArchive:
             if self.pull:
                 logger.info('# Pulling changes to starred repos...\n')
                 _ = iterate_repos_to_archive(self, starred_repos, PULL_OPERATION)
+            if self.fork:
+                logger.info('# Forking starred repos...\n')
+                iterate_repos_to_fork(starred_repos)
 
         if failed_repo_dirs:
             logger.info('Cleaning up repos...\n')
@@ -191,6 +205,9 @@ class GithubArchive:
             if self.pull:
                 logger.info('# Pulling changes to gists...\n')
                 _ = iterate_gists_to_archive(self, gists, PULL_OPERATION)
+            if self.fork:
+                logger.info('# Forking gists...\n')
+                iterate_gists_to_fork(gists)
 
             if failed_gist_dirs:
                 logger.info('Cleaning up gists...\n')
@@ -213,17 +230,23 @@ class GithubArchive:
             os.makedirs(os.path.join(self.location, 'repos'))
             os.makedirs(os.path.join(self.location, 'gists'))
 
-        if (self.users or self.orgs or self.gists or self.stars) and not (self.view or self.clone or self.pull):
+        if (self.users or self.orgs or self.gists or self.stars) and not (
+            self.view or self.clone or self.pull or self.fork
+        ):
             log_and_raise_value_error(
                 logger=logger,
                 message='A git operation must be specified when a list of users or orgs is provided.',
             )
-        elif not (self.users or self.orgs or self.gists or self.stars) and (self.view or self.clone or self.pull):
+        elif not (self.users or self.orgs or self.gists or self.stars) and (
+            self.view or self.clone or self.pull or self.fork
+        ):
             log_and_raise_value_error(
                 logger=logger,
                 message='A list must be provided when a git operation is specified.',
             )
-        elif not (self.users or self.orgs or self.gists or self.stars or self.view or self.clone or self.pull):
+        elif not (
+            self.users or self.orgs or self.gists or self.stars or self.view or self.clone or self.pull or self.fork
+        ):
             log_and_raise_value_error(
                 logger=logger,
                 message='At least one git operation and one list must be provided to run github-archive.',

--- a/github_archive/archive.py
+++ b/github_archive/archive.py
@@ -54,10 +54,11 @@ class GithubArchive:
         view=False,
         clone=False,
         pull=False,
-        forks=False,
-        location=DEFAULT_LOCATION,
+        fork=False,
         include=None,
         exclude=None,
+        forks=False,
+        location=DEFAULT_LOCATION,
         use_https=False,
         timeout=DEFAULT_TIMEOUT,
         threads=DEFAULT_NUM_THREADS,
@@ -73,10 +74,11 @@ class GithubArchive:
         self.view = view
         self.clone = clone
         self.pull = pull
-        self.forks = forks
-        self.location = location
+        self.fork = fork
         self.include = include.lower().split(',') if include else ''
         self.exclude = exclude.lower().split(',') if exclude else ''
+        self.forks = forks
+        self.location = location
         self.use_https = use_https
         self.timeout = timeout
         self.threads = threads

--- a/github_archive/cli.py
+++ b/github_archive/cli.py
@@ -88,14 +88,13 @@ class GithubArchiveCli:
         )
         parser.add_argument(
             '-f',
-            '--forks',
+            '--fork',
             action='store_true',
             required=False,
             default=False,
-            help='Pass this flag to include forked git assets.',
+            help='Pass this flag to fork git assets.',
         )
         parser.add_argument(
-            '-i',
             '--include',
             type=str,
             required=False,
@@ -103,7 +102,6 @@ class GithubArchiveCli:
             help='Pass a comma separated list of repos to filter what is included in the Archive.',
         )
         parser.add_argument(
-            '-e',
             '--exclude',
             type=str,
             required=False,
@@ -111,17 +109,20 @@ class GithubArchiveCli:
             help='Pass a comma separated list of repos to filter what is excluded from the Archive.',
         )
         parser.add_argument(
-            '-l',
+            '--forks',
+            action='store_true',
+            required=False,
+            default=False,
+            help='Pass this flag to include forked git assets (when cloning or pulling).',
+        )
+        parser.add_argument(
             '--location',
             type=str,
             required=False,
             default=DEFAULT_LOCATION,
-            help=(
-                f'The location where you want your GitHub Archive to be stored. By default, this is: {DEFAULT_LOCATION}'
-            ),
+            help=(f'The location where you want your GitHub Archive to be stored. Default: {DEFAULT_LOCATION}'),
         )
         parser.add_argument(
-            '-ht',
             '--https',
             action='store_true',
             required=False,
@@ -129,27 +130,25 @@ class GithubArchiveCli:
             help='Use HTTPS URLs instead of SSH.',
         )
         parser.add_argument(
-            '-to',
             '--timeout',
             type=int,
             required=False,
             default=DEFAULT_TIMEOUT,
-            help='The number of seconds before a git operation times out.',
+            help=f'The number of seconds before a git operation times out. Default: {DEFAULT_TIMEOUT}',
         )
         parser.add_argument(
-            '-th',
             '--threads',
             type=int,
             required=False,
             default=DEFAULT_NUM_THREADS,
-            help='The number of concurrent threads to run.',
+            help=f'The number of concurrent threads to run. Default: {DEFAULT_NUM_THREADS}',
         )
         parser.add_argument(
             '--base_url',
             type=str,
             required=False,
             default=DEFAULT_BASE_URL,
-            help='The base URL of your GitHub instance (useful for enterprise users with custom hostnames).',
+            help=f'The base URL of your GitHub instance (useful for enterprise users with custom hostnames). Default: {DEFAULT_BASE_URL}',
         )
         parser.add_argument(
             '--log_level',
@@ -157,7 +156,7 @@ class GithubArchiveCli:
             required=False,
             default=DEFAULT_LOG_LEVEL,
             choices=set(get_args(LOG_LEVEL_CHOICES)),
-            help='The log level used for the tool.',
+            help=f'The log level used for the tool. Default: {DEFAULT_LOG_LEVEL}',
         )
         parser.parse_args(namespace=self)
 
@@ -171,10 +170,11 @@ class GithubArchiveCli:
             view=self.view,
             clone=self.clone,
             pull=self.pull,
-            forks=self.forks,
-            location=self.location,
+            fork=self.fork,
             include=self.include,
             exclude=self.exclude,
+            forks=self.forks,
+            location=self.location,
             use_https=self.https,
             timeout=self.timeout,
             threads=self.threads,

--- a/github_archive/cli.py
+++ b/github_archive/cli.py
@@ -148,7 +148,7 @@ class GithubArchiveCli:
             type=str,
             required=False,
             default=DEFAULT_BASE_URL,
-            help=f'The base URL of your GitHub instance (useful for enterprise users with custom hostnames). Default: {DEFAULT_BASE_URL}',
+            help=f'The base URL of your GitHub instance (useful for enterprise users with custom hostnames). Default: {DEFAULT_BASE_URL}',  # noqa
         )
         parser.add_argument(
             '--log_level',

--- a/github_archive/cli.py
+++ b/github_archive/cli.py
@@ -120,7 +120,7 @@ class GithubArchiveCli:
             type=str,
             required=False,
             default=DEFAULT_LOCATION,
-            help=(f'The location where you want your GitHub Archive to be stored. Default: {DEFAULT_LOCATION}'),
+            help=f'The location where you want your GitHub Archive to be stored. Default: {DEFAULT_LOCATION}',
         )
         parser.add_argument(
             '--https',
@@ -148,7 +148,10 @@ class GithubArchiveCli:
             type=str,
             required=False,
             default=DEFAULT_BASE_URL,
-            help=f'The base URL of your GitHub instance (useful for enterprise users with custom hostnames). Default: {DEFAULT_BASE_URL}',  # noqa
+            help=(  # noqa
+                'The base URL of your GitHub instance (useful for enterprise users with custom hostnames). Default:'
+                f' {DEFAULT_BASE_URL}'
+            ),
         )
         parser.add_argument(
             '--log_level',

--- a/github_archive/gists.py
+++ b/github_archive/gists.py
@@ -64,7 +64,11 @@ def view_gists(gists: List[Gist.Gist]):
 
 def fork_gist(gist: Gist.Gist):
     """Forks a gist to the authenticated user's GitHub instance."""
+    logger = woodchips.get(LOGGER_NAME)
+
     gist.create_fork()
+    gist_id = f'{gist.owner.login}/{gist.id}'
+    logger.info(f'{gist_id} forked!')
 
 
 def _archive_gist(github_archive: GithubArchive, gist: Gist.Gist, gist_path: str, operation: str) -> Optional[str]:

--- a/github_archive/gists.py
+++ b/github_archive/gists.py
@@ -62,13 +62,23 @@ def view_gists(gists: List[Gist.Gist]):
         logger.info(gist_id)
 
 
-def fork_gist(gist: Gist.Gist):
+def iterate_gists_to_fork(gists: List[Gist.Gist]):
+    """Iterates through a list of gists and attempts to fork them."""
+    for gist in gists:
+        _fork_gist(gist)
+
+
+def _fork_gist(gist: Gist.Gist):
     """Forks a gist to the authenticated user's GitHub instance."""
     logger = woodchips.get(LOGGER_NAME)
 
-    gist.create_fork()
     gist_id = f'{gist.owner.login}/{gist.id}'
-    logger.info(f'{gist_id} forked!')
+
+    try:
+        gist.create_fork()
+        logger.info(f'{gist_id} forked!')
+    except Exception:
+        logger.warning(f'{gist_id} failed to fork!')
 
 
 def _archive_gist(github_archive: GithubArchive, gist: Gist.Gist, gist_path: str, operation: str) -> Optional[str]:

--- a/github_archive/gists.py
+++ b/github_archive/gists.py
@@ -62,6 +62,11 @@ def view_gists(gists: List[Gist.Gist]):
         logger.info(gist_id)
 
 
+def fork_gist(gist: Gist.Gist):
+    """Forks a gist to the authenticated user's GitHub instance."""
+    gist.create_fork()
+
+
 def _archive_gist(github_archive: GithubArchive, gist: Gist.Gist, gist_path: str, operation: str) -> Optional[str]:
     """Clone and pull gists based on the operation passed.
 

--- a/github_archive/repos.py
+++ b/github_archive/repos.py
@@ -74,6 +74,11 @@ def view_repos(repos: List[Repository.Repository]):
         logger.info(repo_name)
 
 
+def fork_repo(repo: Repository.Repository):
+    """Forks a repository to the authenticated user's GitHub instance."""
+    repo.create_fork()
+
+
 def _archive_repo(
     github_archive: GithubArchive, repo: Repository.Repository, repo_path: str, operation: str
 ) -> Optional[str]:

--- a/github_archive/repos.py
+++ b/github_archive/repos.py
@@ -31,7 +31,8 @@ from github_archive.constants import (
 def iterate_repos_to_archive(
     github_archive: GithubArchive, repos: List[Repository.Repository], operation: str
 ) -> List[Optional[str]]:
-    """Iterate over each repository and start a thread if it can be archived.
+    """Iterate over each repository and start a thread after filtering based on the
+    user input and attempt to archive it.
 
     We ignore repos not in the include or in the exclude list if either are present.
     """
@@ -74,13 +75,23 @@ def view_repos(repos: List[Repository.Repository]):
         logger.info(repo_name)
 
 
-def fork_repo(repo: Repository.Repository):
+def iterate_repos_to_fork(repos: List[Repository.Repository]):
+    """Iterates through a list of repos and attempts to fork them."""
+    for repo in repos:
+        _fork_repo(repo)
+
+
+def _fork_repo(repo: Repository.Repository):
     """Forks a repository to the authenticated user's GitHub instance."""
     logger = woodchips.get(LOGGER_NAME)
 
-    repo.create_fork()
     repo_name = f'{repo.owner.login}/{repo.name}'
-    logger.info(f'{repo_name} forked!')
+
+    try:
+        repo.create_fork()
+        logger.info(f'{repo_name} forked!')
+    except Exception:
+        logger.error(f'{repo_name} failed to fork!')
 
 
 def _archive_repo(

--- a/github_archive/repos.py
+++ b/github_archive/repos.py
@@ -76,7 +76,11 @@ def view_repos(repos: List[Repository.Repository]):
 
 def fork_repo(repo: Repository.Repository):
     """Forks a repository to the authenticated user's GitHub instance."""
+    logger = woodchips.get(LOGGER_NAME)
+
     repo.create_fork()
+    repo_name = f'{repo.owner.login}/{repo.name}'
+    logger.info(f'{repo_name} forked!')
 
 
 def _archive_repo(

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
     name='github-archive',
     version='4.5.1',
     description=(
-        'A powerful tool to concurrently clone or pull user and org repos and gists to create a GitHub archive.'
+        'A powerful tool to concurrently clone, pull, or fork user and org repos and gists to create a GitHub archive.'
     ),
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/test/unit/test_gists.py
+++ b/test/unit/test_gists.py
@@ -85,10 +85,12 @@ def test_view_gists(mock_logger, mock_git_asset):
     mock_logger.assert_called_with('mock_username/123')
 
 
+@patch('logging.Logger.info')
 @patch('github.Gist.Gist.create_fork')
-def test_fork_gist(mock_create_fork):
+def test_fork_gist(mock_create_fork, mock_logger):
     gist = MagicMock(spec=Gist.Gist)
     gist.create_fork = mock_create_fork
     fork_gist(gist)
 
     mock_create_fork.assert_called_once()
+    mock_logger.assert_called_once()

--- a/test/unit/test_gists.py
+++ b/test/unit/test_gists.py
@@ -88,6 +88,7 @@ def test_view_gists(mock_logger, mock_git_asset):
 @patch('github.Gist.Gist.create_fork')
 def test_fork_gist(mock_create_fork):
     gist = MagicMock(spec=Gist.Gist)
+    gist.create_fork = mock_create_fork
     fork_gist(gist)
 
     mock_create_fork.assert_called_once()

--- a/test/unit/test_gists.py
+++ b/test/unit/test_gists.py
@@ -13,8 +13,9 @@ from github_archive.archive import (
 )
 from github_archive.gists import (
     _archive_gist,
-    fork_gist,
+    _fork_gist,
     iterate_gists_to_archive,
+    iterate_gists_to_fork,
     view_gists,
 )
 
@@ -85,12 +86,31 @@ def test_view_gists(mock_logger, mock_git_asset):
     mock_logger.assert_called_with('mock_username/123')
 
 
+@patch('github_archive.gists._fork_gist')
+def test_iterate_gists_to_fork(mock_fork_gist):
+    gist = MagicMock(spec=Gist.Gist)
+    iterate_gists_to_fork([gist])
+
+    mock_fork_gist.assert_called_once()
+
+
 @patch('logging.Logger.info')
 @patch('github.Gist.Gist.create_fork')
-def test_fork_gist(mock_create_fork, mock_logger):
+def test_fork_gist_success(mock_create_fork, mock_logger):
     gist = MagicMock(spec=Gist.Gist)
     gist.create_fork = mock_create_fork
-    fork_gist(gist)
+    _fork_gist(gist)
+
+    mock_create_fork.assert_called_once()
+    mock_logger.assert_called_once()
+
+
+@patch('logging.Logger.warning')
+@patch('github.Gist.Gist.create_fork', side_effect=Exception())
+def test_fork_gist_failure(mock_create_fork, mock_logger):
+    gist = MagicMock(spec=Gist.Gist)
+    gist.create_fork = mock_create_fork
+    _fork_gist(gist)
 
     mock_create_fork.assert_called_once()
     mock_logger.assert_called_once()

--- a/test/unit/test_gists.py
+++ b/test/unit/test_gists.py
@@ -1,5 +1,10 @@
 import subprocess
-from unittest.mock import patch
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
+from github import Gist
 
 from github_archive import GithubArchive
 from github_archive.archive import (
@@ -8,6 +13,7 @@ from github_archive.archive import (
 )
 from github_archive.gists import (
     _archive_gist,
+    fork_gist,
     iterate_gists_to_archive,
     view_gists,
 )
@@ -77,3 +83,11 @@ def test_view_gists(mock_logger, mock_git_asset):
     view_gists(gists)
 
     mock_logger.assert_called_with('mock_username/123')
+
+
+@patch('github.Gist.Gist.create_fork')
+def test_fork_gist(mock_create_fork):
+    gist = MagicMock(spec=Gist.Gist)
+    fork_gist(gist)
+
+    mock_create_fork.assert_called_once()

--- a/test/unit/test_repos.py
+++ b/test/unit/test_repos.py
@@ -1,5 +1,10 @@
 import subprocess
-from unittest.mock import patch
+from unittest.mock import (
+    MagicMock,
+    patch,
+)
+
+from github import Repository
 
 from github_archive import GithubArchive
 from github_archive.archive import (
@@ -8,6 +13,7 @@ from github_archive.archive import (
 )
 from github_archive.repos import (
     _archive_repo,
+    fork_repo,
     iterate_repos_to_archive,
     view_repos,
 )
@@ -137,3 +143,11 @@ def test_archive_repo_called_process_error(mock_logger, mock_subprocess, mock_gi
     _archive_repo(github_archive, mock_git_asset, 'github_archive', operation)
 
     mock_logger.assert_called_once()
+
+
+@patch('github.Repository.Repository.create_fork')
+def test_fork_repo(mock_create_fork):
+    repo = MagicMock(spec=Repository.Repository)
+    fork_repo(repo)
+
+    mock_create_fork.assert_called_once()

--- a/test/unit/test_repos.py
+++ b/test/unit/test_repos.py
@@ -148,6 +148,7 @@ def test_archive_repo_called_process_error(mock_logger, mock_subprocess, mock_gi
 @patch('github.Repository.Repository.create_fork')
 def test_fork_repo(mock_create_fork):
     repo = MagicMock(spec=Repository.Repository)
+    repo.create_fork = mock_create_fork
     fork_repo(repo)
 
-    mock_create_fork.assert_called_once()
+    mock_create_fork.assert_called_once_with()

--- a/test/unit/test_repos.py
+++ b/test/unit/test_repos.py
@@ -145,10 +145,12 @@ def test_archive_repo_called_process_error(mock_logger, mock_subprocess, mock_gi
     mock_logger.assert_called_once()
 
 
+@patch('logging.Logger.info')
 @patch('github.Repository.Repository.create_fork')
-def test_fork_repo(mock_create_fork):
+def test_fork_repo(mock_create_fork, mock_logger):
     repo = MagicMock(spec=Repository.Repository)
     repo.create_fork = mock_create_fork
     fork_repo(repo)
 
     mock_create_fork.assert_called_once_with()
+    mock_logger.assert_called_once()

--- a/test/unit/test_repos.py
+++ b/test/unit/test_repos.py
@@ -13,8 +13,9 @@ from github_archive.archive import (
 )
 from github_archive.repos import (
     _archive_repo,
-    fork_repo,
+    _fork_repo,
     iterate_repos_to_archive,
+    iterate_repos_to_fork,
     view_repos,
 )
 
@@ -145,12 +146,31 @@ def test_archive_repo_called_process_error(mock_logger, mock_subprocess, mock_gi
     mock_logger.assert_called_once()
 
 
+@patch('github_archive.repos._fork_repo')
+def test_iterate_repos_to_fork(mock_fork_repo):
+    repo = MagicMock(spec=Repository.Repository)
+    iterate_repos_to_fork([repo])
+
+    mock_fork_repo.assert_called_once()
+
+
 @patch('logging.Logger.info')
 @patch('github.Repository.Repository.create_fork')
-def test_fork_repo(mock_create_fork, mock_logger):
+def test_fork_repo_success(mock_create_fork, mock_logger):
     repo = MagicMock(spec=Repository.Repository)
     repo.create_fork = mock_create_fork
-    fork_repo(repo)
+    _fork_repo(repo)
 
-    mock_create_fork.assert_called_once_with()
+    mock_create_fork.assert_called_once()
+    mock_logger.assert_called_once()
+
+
+@patch('logging.Logger.error')
+@patch('github.Repository.Repository.create_fork', side_effect=Exception())
+def test_fork_repo_failure(mock_create_fork, mock_logger):
+    repo = MagicMock(spec=Repository.Repository)
+    repo.create_fork = mock_create_fork
+    _fork_repo(repo)
+
+    mock_create_fork.assert_called_once()
     mock_logger.assert_called_once()


### PR DESCRIPTION
This PR adds support to fork repos and gists by passing the `--fork` flag along with the `--users`, `--orgs`, `--stars`, or `--gists` flags.

Closes #49.